### PR TITLE
Apply `isort` to project

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -1,5 +1,6 @@
 from flask import Flask, jsonify
 from marshmallow import Schema, fields
+
 from marshmallow_jsonschema import JSONSchema
 
 app = Flask(__name__)

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -1,16 +1,14 @@
 import datetime
 import decimal
+import typing
 import uuid
 from enum import Enum
 from inspect import isclass
-import typing
 
-from marshmallow import fields, missing, Schema, validate
+from marshmallow import EXCLUDE, INCLUDE, RAISE, Schema, fields, missing, validate
 from marshmallow.class_registry import get_class
 from marshmallow.decorators import post_dump
 from marshmallow.utils import _Missing
-
-from marshmallow import INCLUDE, EXCLUDE, RAISE
 
 try:
     from marshmallow_union import Union

--- a/marshmallow_jsonschema/extensions/__init__.py
+++ b/marshmallow_jsonschema/extensions/__init__.py
@@ -1,4 +1,3 @@
 from .react_jsonschema_form import ReactJsonSchemaFormJSONSchema
 
-
 __all__ = ("ReactJsonSchemaFormJSONSchema",)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.black]
 target-version = ['py36', 'py37', 'py38']
+
+[tool.isort]
+profile = "black"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,3 +8,4 @@ marshmallow-union
 mypy>=0.910
 
 pre-commit~=2.15
+isort

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 import io
 import os
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/tests/test_additional_properties.py
+++ b/tests/test_additional_properties.py
@@ -1,7 +1,8 @@
 import pytest
-from marshmallow import Schema, fields, RAISE, INCLUDE, EXCLUDE
+from marshmallow import EXCLUDE, INCLUDE, RAISE, Schema, fields
 
-from marshmallow_jsonschema import UnsupportedValueError, JSONSchema
+from marshmallow_jsonschema import JSONSchema, UnsupportedValueError
+
 from . import validate_and_dump
 
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -7,6 +7,7 @@ from marshmallow_enum import EnumField
 from marshmallow_union import Union
 
 from marshmallow_jsonschema import JSONSchema, UnsupportedValueError
+
 from . import UserSchema, validate_and_dump
 
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,4 +1,5 @@
 import importlib
+
 import marshmallow_jsonschema
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -7,6 +7,7 @@ from marshmallow_enum import EnumField
 from marshmallow_union import Union
 
 from marshmallow_jsonschema import JSONSchema, UnsupportedValueError
+
 from . import UserSchema, validate_and_dump
 
 


### PR DESCRIPTION
to have a stable order of the imports, regardless of individual IDE settings.

https://pycqa.github.io/isort/